### PR TITLE
Add poetry prose delimiter and better detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ const options = {
         pairWordCountSimilarityRatio: 0.5, // Word count similarity for poetry pairs
         wordDensityComparisonRatio: 0.95, // Density comparison for wide poetry lines
     },
+    poetryPairDelimiter: ' ... ', // Delimiter when merging hemistich pairs
 
     // Layout structure (optional)
     horizontalLines: [], // Array of horizontal line bounding boxes for footnote detection
@@ -206,11 +207,11 @@ Groups observations into lines based on vertical proximity, applies centering de
 
 - **Parameters:**
     - `observations`: Array of OCR text observations
-    - `dpi`: Document DPI information including width and height
+    - `page`: Page dimensions and DPI information
     - `options`: Configuration options for text line processing
 - **Returns:** Array of text blocks with metadata (centering, headings, footnotes, poetry)
 
-#### `mapTextLinesToParagraphs(textLines: TextBlock[], options?: Partial<ParagraphOptions>): TextBlock[]`
+#### `mapTextLinesToParagraphs(textLines: TextBlock[], options?: ParagraphOptions): TextBlock[]`
 
 Groups text lines into coherent paragraphs, handling both prose and poetry.
 
@@ -318,6 +319,7 @@ type MapObservationsToTextLinesOptions = CenteringOptions & {
     pixelTolerance?: number; // Default: 5
     lineHeightFactor?: number; // Optional fixed line height factor
     poetryDetectionOptions?: PoetryDetectionOptions;
+    poetryPairDelimiter?: string; // Default: " "
     horizontalLines?: BoundingBox[]; // For footnote detection
     rectangles?: BoundingBox[]; // For heading detection
     log?: (message: string, ...args: any[]) => void; // Debug logging

--- a/bun.lock
+++ b/bun.lock
@@ -35,23 +35,23 @@
 
     "@babel/types": ["@babel/types@8.0.0-rc.1", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.1", "@babel/helper-validator-identifier": "^8.0.0-rc.1" } }, "sha512-ubmJ6TShyaD69VE9DQrlXcdkvJbmwWPB8qYj0H2kaJi29O7vJT9ajSdBd2W8CG34pwL9pYA74fi7RHC1qbLoVQ=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.3.14", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.14", "@biomejs/cli-darwin-x64": "2.3.14", "@biomejs/cli-linux-arm64": "2.3.14", "@biomejs/cli-linux-arm64-musl": "2.3.14", "@biomejs/cli-linux-x64": "2.3.14", "@biomejs/cli-linux-x64-musl": "2.3.14", "@biomejs/cli-win32-arm64": "2.3.14", "@biomejs/cli-win32-x64": "2.3.14" }, "bin": { "biome": "bin/biome" } }, "sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.3.15", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.15", "@biomejs/cli-darwin-x64": "2.3.15", "@biomejs/cli-linux-arm64": "2.3.15", "@biomejs/cli-linux-arm64-musl": "2.3.15", "@biomejs/cli-linux-x64": "2.3.15", "@biomejs/cli-linux-x64-musl": "2.3.15", "@biomejs/cli-win32-arm64": "2.3.15", "@biomejs/cli-win32-x64": "2.3.15" }, "bin": { "biome": "bin/biome" } }, "sha512-u+jlPBAU2B45LDkjjNNYpc1PvqrM/co4loNommS9/sl9oSxsAQKsNZejYuUztvToB5oXi1tN/e62iNd6ESiY3g=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UJGPpvWJMkLxSRtpCAKfKh41Q4JJXisvxZL8ChN1eNW3m/WlPFJ6EFDCE7YfUb4XS8ZFi3C1dFpxUJ0Ety5n+A=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-SDCdrJ4COim1r8SNHg19oqT50JfkI/xGZHSyC6mGzMfKrpNe/217Eq6y98XhNTc0vGWDjznSDNXdUc6Kg24jbw=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-PNkLNQG6RLo8lG7QoWe/hhnMxJIt1tEimoXpGQjwS/dkdNiKBLPv4RpeQl8o3s1OKI3ZOR5XPiYtmbGGHAOnLA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-RkyeSosBtn3C3Un8zQnl9upX0Qbq4E3QmBa0qjpOh1MebRbHhNlRC16jk8HdTe/9ym5zlfnpbb8cKXzW+vlTxw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-KT67FKfzIw6DNnUNdYlBg+eU24Go3n75GWK6NwU4+yJmDYFe9i/MjiI+U/iEzKvo0g7G7MZqoyrhIYuND2w8QQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-FN83KxrdVWANOn5tDmW6UBC0grojchbGmcEz6JkRs2YY6DY63sTZhwkQ56x6YtKhDVV1Unz7FJexy8o7KwuIhg=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-LInRbXhYujtL3sH2TMCH/UBwJZsoGwfQjBrMfl84CD4hL/41C/EU5mldqf1yoFpsI0iPWuU83U+nB2TUUypWeg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-SSSIj2yMkFdSkXqASzIBdjySBXOe65RJlhKEDlri7MN19RC4cpez+C0kEwPrhXOTgJbwQR9QH1F4+VnHkC35pg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-ZsZzQsl9U+wxFrGGS4f6UxREUlgHwmEfu1IrXlgNFrNnd5Th6lIJr8KmSzu/+meSa9f4rzFrbEW9LBBA6ScoMA=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.15", "", { "os": "linux", "cpu": "x64" }, "sha512-T8n9p8aiIKOrAD7SwC7opiBM1LYGrE5G3OQRXWgbeo/merBk8m+uxJ1nOXMPzfYyFLfPlKF92QS06KN1UW+Zbg=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-KQU7EkbBBuHPW3/rAcoiVmhlPtDSGOGRPv9js7qJVpYTzjQmVR+C9Rfcz+ti8YCH+zT1J52tuBybtP4IodjxZQ=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.15", "", { "os": "linux", "cpu": "x64" }, "sha512-dbjPzTh+ijmmNwojFYbQNMFp332019ZDioBYAMMJj5Ux9d8MkM+u+J68SBJGVwVeSHMYj+T9504CoxEzQxrdNw=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-+IKYkj/pUBbnRf1G1+RlyA3LWiDgra1xpS7H2g4BuOzzRbRB+hmlw0yFsLprHhbbt7jUzbzAbAjK/Pn0FDnh1A=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-puMuenu/2brQdgqtQ7geNwQlNVxiABKEZJhMRX6AGWcmrMO8EObMXniFQywy2b81qmC+q+SDvlOpspNwz0WiOA=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.15", "", { "os": "win32", "cpu": "x64" }, "sha512-kDZr/hgg+igo5Emi0LcjlgfkoGZtgIpJKhnvKTRmMBv6FF/3SDyEV4khBwqNebZIyMZTzvpca9sQNSXJ39pI2A=="],
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "kokokor": "^2.1.0",
+        "kokokor": "^2.2.0",
         "vue": "^3.5.28"
     },
     "devDependencies": {

--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -86,6 +86,7 @@ const rows = computed<DemoRow[]>(() => {
 
             const lines = mapObservationsToTextLines(fixture.observations, page, {
                 horizontalLines: structure.horizontal_lines,
+                poetryPairDelimiter: ' … ',
                 rectangles: structure.rectangles,
             });
             const paragraphs = mapTextLinesToParagraphs(lines);

--- a/package.json
+++ b/package.json
@@ -49,5 +49,5 @@
     "source": "src/index.ts",
     "type": "module",
     "types": "dist/index.d.ts",
-    "version": "2.1.0"
+    "version": "2.2.0"
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
         "typescript": "^5.9.3"
     },
     "engines": {
-        "bun": ">=1.3.2",
-        "node": ">=22.0.0"
+        "bun": ">=1.3.9",
+        "node": ">=24.0.0"
     },
     "files": [
         "dist",
@@ -33,6 +33,7 @@
     "license": "MIT",
     "main": "dist/index.js",
     "name": "kokokor",
+    "packageManager": "bun@1.3.9",
     "repository": {
         "type": "git",
         "url": "https://github.com/ragaeeb/kokokor.git"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     },
     "description": "A lightweight TypeScript library designed to reconstruct paragraphs from OCRed inputs.",
     "devDependencies": {
-        "@biomejs/biome": "^2.3.14",
+        "@biomejs/biome": "^2.3.15",
         "@types/bun": "^1.3.9",
         "@types/node": "^25.2.3",
         "semantic-release": "^25.0.3",

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,6 +117,15 @@ export type MapObservationsToTextLinesOptions = CenteringOptions & {
     poetryDetectionOptions?: Partial<PoetryDetectionOptions>;
 
     /**
+     * Delimiter used when merging a detected poetry pair (hemistichs) into a single line.
+     *
+     * Example: `" ... "` formats a pair as `صدر ... عجز`.
+     *
+     * @default " "
+     */
+    poetryPairDelimiter?: string;
+
+    /**
      * Optional array of rectangular elements detected in the document.
      * These are typically used to identify text boxes, highlighted sections, or headers.
      * When provided, text within these rectangles may be classified as headings.

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -47,6 +47,8 @@ export const DEFAULT_OBSERVATIONS_TO_TEXT_LINES_OPTIONS: MapObservationsToTextLi
     pixelTolerance: 5,
     /** Default poetry detection options */
     poetryDetectionOptions: DEFAULT_POETRY_OPTIONS,
+    /** Default delimiter for merged poetry pairs (hemistichs) */
+    poetryPairDelimiter: ' ',
     /** Empty array of rectangles - will be populated during processing */
     rectangles: [],
 } as const;

--- a/src/utils/grouping.ts
+++ b/src/utils/grouping.ts
@@ -96,7 +96,7 @@ export const mergeObservations = <T extends Observation>(group: T[], delimiter =
         maxX = Math.max(maxX, bbox.x + bbox.width);
         maxY = Math.max(maxY, bbox.y + bbox.height);
 
-        // Append text with space
+        // Append text with delimiter
         combinedText += `${delimiter}${text}`;
     }
 

--- a/src/utils/grouping.ts
+++ b/src/utils/grouping.ts
@@ -73,9 +73,10 @@ export const sortGroupsHorizontally = <T extends { bbox: { x: number } }>(groupe
 /**
  * Merges the group of observations into a single one.
  * @param group The group of observations to merge.
+ * @param delimiter Text delimiter used when concatenating observations.
  * @returns A single observation with the text of the group concatenated as well as the bounding box adjusted to fit all of the contents.
  */
-export const mergeObservations = <T extends Observation>(group: T[]): T => {
+export const mergeObservations = <T extends Observation>(group: T[], delimiter = ' '): T => {
     // Initialize with the first observation's values
     let minX = group[0].bbox.x;
     let minY = group[0].bbox.y;
@@ -96,7 +97,7 @@ export const mergeObservations = <T extends Observation>(group: T[]): T => {
         maxY = Math.max(maxY, bbox.y + bbox.height);
 
         // Append text with space
-        combinedText += ' ' + text;
+        combinedText += `${delimiter}${text}`;
     }
 
     // Create the merged observation, preserving all properties from the first observation

--- a/src/utils/paragraphs.test.ts
+++ b/src/utils/paragraphs.test.ts
@@ -284,6 +284,34 @@ describe('paragraphs', () => {
             ]);
         });
 
+        it('should merge a pair of poetry lines using the configured delimiter', () => {
+            defaultDpi.width = 2480;
+
+            const actual = mapObservationsToTextLines(
+                [
+                    { bbox: { height: 20, width: 600, x: 479, y: 0 }, text: 'A B C D' },
+                    { bbox: { height: 20, width: 600, x: 1260, y: 0 }, text: 'E F G H' },
+                ],
+                defaultDpi,
+                {
+                    poetryPairDelimiter: ' ... ',
+                },
+            );
+
+            expect(actual).toEqual([
+                {
+                    bbox: {
+                        height: 20,
+                        width: 1381,
+                        x: 620,
+                        y: 0,
+                    },
+                    isPoetic: true,
+                    text: 'E F G H ... A B C D',
+                },
+            ]);
+        });
+
         it('should merge lines that were broken up by OCR engine', () => {
             const actual = mapObservationsToTextLines(
                 [
@@ -291,6 +319,9 @@ describe('paragraphs', () => {
                     { bbox: { height: 20, width: 200, x: 500, y: 5 }, text: 'CD' },
                 ],
                 defaultDpi,
+                {
+                    poetryPairDelimiter: ' ... ',
+                },
             );
 
             expect(actual).toEqual([

--- a/src/utils/paragraphs.ts
+++ b/src/utils/paragraphs.ts
@@ -8,7 +8,7 @@ import type {
 } from '@/types';
 
 import { DEFAULT_OBSERVATIONS_TO_TEXT_LINES_OPTIONS, DEFAULT_POETRY_OPTIONS } from './constants';
-import { groupByIndex, mergeGroupedObservations, sortGroupsHorizontally } from './grouping';
+import { groupByIndex, mergeGroupedObservations, mergeObservations, sortGroupsHorizontally } from './grouping';
 import { getLastHorizontalLineY, isBoundingBoxContained, isObservationCentered } from './layout';
 import { indexItemsAsLines, indexItemsAsParagraphs } from './marking';
 import {
@@ -26,6 +26,9 @@ const DEFAULT_PARAGRAPH_OPTIONS: ResolvedParagraphOptions = {
     verticalJumpFactor: 2,
     widthTolerance: 0.85,
 };
+
+const isPoetryPairGroup = (group: (Observation & { isPoetic?: boolean })[]) =>
+    group.length === 2 && group.every((item) => item.isPoetic);
 
 /**
  * Preprocesses observations by filtering noise, flipping coordinates for RTL text,
@@ -168,7 +171,16 @@ export const mapObservationsToTextLines = (
         }
     }
 
-    return mergeGroupedObservations(groups) as TextBlock[];
+    const merged = groups.map((group) => {
+        if (group.length === 1) {
+            return group[0];
+        }
+
+        const delimiter = isPoetryPairGroup(group) ? (options.poetryPairDelimiter ?? ' ') : ' ';
+        return mergeObservations(group, delimiter);
+    });
+
+    return merged as TextBlock[];
 };
 
 /**

--- a/src/utils/poetry.test.ts
+++ b/src/utils/poetry.test.ts
@@ -158,6 +158,39 @@ describe('poetry', () => {
             // Only first and third observations should count (6 + 3 words, 450 + 420 width)
             expect(density).toBeCloseTo(9 / 870, 5);
         });
+
+        it('should count words robustly with multiple spaces, NBSP, and tatweel', () => {
+            const observations = [createObservation('alpha\u00A0\u00A0beta   بــــيت   gamma', 50, 100, 450)];
+
+            const density = calculateAverageProseDensity(observations, imageWidth, {
+                centerToleranceRatio: 0.05,
+                minMarginRatio: 0.1,
+                minWordCount: 2,
+            });
+
+            expect(density).toBeCloseTo(4 / 450, 5);
+        });
+
+        it('should use shared word count consistently in prose density and pair checks', () => {
+            const proseDensity = calculateAverageProseDensity(
+                [createObservation('alpha   beta', 50, 100, 450)],
+                imageWidth,
+                {
+                    centerToleranceRatio: 0.05,
+                    minMarginRatio: 0.1,
+                    minWordCount: 3,
+                },
+            );
+            const pair = isPoetryPair(
+                createObservation('alpha   beta', 300, 100, 180),
+                createObservation('gamma delta epsilon', 520, 100, 180),
+                imageWidth,
+                { ...DEFAULT_POETRY_OPTIONS, minWordCount: 3 },
+            );
+
+            expect(proseDensity).toBe(0);
+            expect(pair).toBeFalse();
+        });
     });
 
     describe('isPoetryPair', () => {
@@ -237,6 +270,47 @@ describe('poetry', () => {
             );
 
             expect(actual).toBeTrue();
+        });
+
+        it('should reject poetry pair when vertical center gap exceeds maxVerticalGapRatio', () => {
+            const actual = isPoetryPair(
+                createObservation('alpha beta gamma', 300, 100, 180, 20),
+                createObservation('delta epsilon zeta', 520, 300, 180, 20),
+                imageWidth,
+            );
+
+            expect(actual).toBeFalse();
+        });
+
+        it('should accept poetry pair near vertical gap boundary', () => {
+            const actual = isPoetryPair(
+                createObservation('alpha beta gamma', 300, 100, 180, 20),
+                createObservation('delta epsilon zeta', 520, 139, 180, 20),
+                imageWidth,
+            );
+
+            expect(actual).toBeTrue();
+        });
+
+        it('should reject pair when left chunk is numeric-only (ToC-like)', () => {
+            const actual = isPoetryPair(
+                createObservation('(١٢)', 300, 100, 120, 20),
+                createObservation('الفصل', 600, 100, 120, 20),
+                imageWidth,
+                { ...DEFAULT_POETRY_OPTIONS, minWordCount: 1 },
+            );
+
+            expect(actual).toBeFalse();
+        });
+
+        it('should reject asymmetric cross-column-like pair under relaxed centering', () => {
+            const actual = isPoetryPair(
+                createObservation('short text', 75, 100, 100, 20),
+                createObservation('other words', 700, 100, 120, 20),
+                imageWidth,
+            );
+
+            expect(actual).toBeFalse();
         });
     });
 
@@ -887,6 +961,17 @@ describe('poetry', () => {
     });
 
     describe('isWidePoeticLine', () => {
+        it('should keep punctuation-reject behavior unchanged for wide single-line poetry', () => {
+            const actual = isWidePoeticLine(
+                createObservation('بيت، شعري جميل', 200, 100, 600),
+                imageWidth,
+                0.02,
+                DEFAULT_POETRY_OPTIONS,
+            );
+
+            expect(actual).toBeFalse();
+        });
+
         it('should be an empty list for an introduction page which is only composed of prose paragraphs', () => {
             const prose = [
                 {

--- a/src/utils/poetry.ts
+++ b/src/utils/poetry.ts
@@ -11,6 +11,13 @@ const DEFAULT_MIN_WORD_COUNT = DEFAULT_POETRY_OPTIONS.minWordCount ?? 2;
 const DEFAULT_PAIR_WIDTH_SIMILARITY = DEFAULT_POETRY_OPTIONS.pairWidthSimilarityRatio ?? 0.4;
 const DEFAULT_PAIR_WORD_SIMILARITY = DEFAULT_POETRY_OPTIONS.pairWordCountSimilarityRatio ?? 0.5;
 const DEFAULT_DENSITY_RATIO = DEFAULT_POETRY_OPTIONS.wordDensityComparisonRatio ?? 0.95;
+const DEFAULT_MAX_VERTICAL_GAP_RATIO = DEFAULT_POETRY_OPTIONS.maxVerticalGapRatio ?? 2.0;
+
+const NBSP_PATTERN = /\u00A0/g;
+const TATWEEL_PATTERN = /\u0640/g;
+const NON_WHITESPACE_PATTERN = /\S+/g;
+const STRIP_PUNCTUATION_SYMBOLS_AND_SPACE_PATTERN = /[\p{P}\p{S}\s]+/gu;
+const ARABIC_OR_LATIN_DIGITS_PATTERN = /^[\d\u0660-\u0669]+$/;
 
 /**
  * Calculates the average word density (words per pixel) for prose text in the document.
@@ -39,7 +46,98 @@ const resolveCenteringOptions = (options?: Partial<CenteringOptions>) =>
         options,
     );
 
-const getWordCount = (text: string) => text.split(' ').length;
+const getWordCount = (text: string) => {
+    const normalized = text.replace(NBSP_PATTERN, ' ').replace(TATWEEL_PATTERN, '').trim();
+    if (!normalized) {
+        return 0;
+    }
+
+    return normalized.match(NON_WHITESPACE_PATTERN)?.length ?? 0;
+};
+
+const isNumericOnlyToken = (text: string) => {
+    const stripped = text
+        .replace(NBSP_PATTERN, ' ')
+        .replace(TATWEEL_PATTERN, '')
+        .replace(STRIP_PUNCTUATION_SYMBOLS_AND_SPACE_PATTERN, '');
+
+    return stripped.length > 0 && ARABIC_OR_LATIN_DIGITS_PATTERN.test(stripped);
+};
+
+const hasCompatiblePairWidths = (obs1: Observation, obs2: Observation, pairWidthSimilarityRatio: number) => {
+    const avgWidth = (obs1.bbox.width + obs2.bbox.width) / 2;
+    const widthDiffRatio = Math.abs(obs1.bbox.width - obs2.bbox.width) / avgWidth;
+
+    return { avgWidth, isCompatible: widthDiffRatio < pairWidthSimilarityRatio };
+};
+
+const hasCompatibleWordCounts = (words1: number, words2: number, pairWordCountSimilarityRatio: number) => {
+    const maxWords = Math.max(words1, words2);
+    const wordCountDiffRatio = Math.abs(words1 - words2) / maxWords;
+
+    return wordCountDiffRatio < pairWordCountSimilarityRatio;
+};
+
+const hasCompatibleVerticalGap = (obs1: Observation, obs2: Observation, maxVerticalGapRatio: number) => {
+    const centerY1 = obs1.bbox.y + obs1.bbox.height / 2;
+    const centerY2 = obs2.bbox.y + obs2.bbox.height / 2;
+    const dy = Math.abs(centerY1 - centerY2);
+    const avgHeight = (obs1.bbox.height + obs2.bbox.height) / 2;
+
+    return dy <= maxVerticalGapRatio * avgHeight;
+};
+
+const getOrderedPairObservations = (obs1: Observation, obs2: Observation) => {
+    const leftObs = obs1.bbox.x < obs2.bbox.x ? obs1 : obs2;
+    const rightObs = obs1.bbox.x < obs2.bbox.x ? obs2 : obs1;
+    const gap = rightObs.bbox.x - (leftObs.bbox.x + leftObs.bbox.width);
+
+    return { gap, leftObs, rightObs };
+};
+
+const hasAsymmetricSparseGap = (
+    leftObs: Observation,
+    rightObs: Observation,
+    gap: number,
+    avgWidth: number,
+    imageWidth: number,
+) => {
+    const pageCenter = imageWidth / 2;
+    const innerLeft = leftObs.bbox.x + leftObs.bbox.width;
+    const innerRight = rightObs.bbox.x;
+    const leftDelta = Math.abs(pageCenter - innerLeft);
+    const rightDelta = Math.abs(innerRight - pageCenter);
+    const asymmetry = Math.abs(leftDelta - rightDelta);
+    const isVerySparsePair = gap > avgWidth * 2;
+
+    return isVerySparsePair && asymmetry > imageWidth * 0.12;
+};
+
+const resolvePairCenteringOptions = (hasSignificantGap: boolean, options: PoetryDetectionOptions) => {
+    if (!hasSignificantGap) {
+        return resolveCenteringOptions(options);
+    }
+
+    return {
+        ...resolveCenteringOptions(options),
+        centerToleranceRatio: (options.centerToleranceRatio ?? DEFAULT_CENTER_TOLERANCE) * 2.5,
+        minMarginRatio: (options.minMarginRatio ?? DEFAULT_MIN_MARGIN) * 0.75,
+    };
+};
+
+const toCombinedBbox = (obs1: Observation, obs2: Observation) => {
+    const leftX = Math.min(obs1.bbox.x, obs2.bbox.x);
+    const rightmostPoint = Math.max(obs1.bbox.x + obs1.bbox.width, obs2.bbox.x + obs2.bbox.width);
+
+    return {
+        height:
+            Math.max(obs1.bbox.y + obs1.bbox.height, obs2.bbox.y + obs2.bbox.height) -
+            Math.min(obs1.bbox.y, obs2.bbox.y),
+        width: rightmostPoint - leftX,
+        x: leftX,
+        y: Math.min(obs1.bbox.y, obs2.bbox.y),
+    };
+};
 
 const hasPoetryLikeDensity = (
     obs: Observation,
@@ -49,7 +147,11 @@ const hasPoetryLikeDensity = (
     minWidthRatioForMerged: number,
     wordDensityComparisonRatio: number,
 ) => {
-    if (obs.bbox.width <= imageWidth * minWidthRatioForMerged || avgProseWordDensity <= 0) {
+    if (
+        obs.bbox.width <= imageWidth * minWidthRatioForMerged ||
+        !Number.isFinite(avgProseWordDensity) ||
+        avgProseWordDensity <= 0
+    ) {
         return false;
     }
 
@@ -80,7 +182,7 @@ export const calculateAverageProseDensity = (
     let totalWidth = 0;
 
     for (const obs of observations) {
-        const wordCount = obs.text.split(' ').length;
+        const wordCount = getWordCount(obs.text);
 
         // Enhanced filtering for better prose identification
         const isLikelyProse =
@@ -95,7 +197,12 @@ export const calculateAverageProseDensity = (
         }
     }
 
-    return totalWords > 0 && totalWidth > 0 ? totalWords / totalWidth : 0;
+    if (totalWords <= 0 || totalWidth <= 0) {
+        return 0;
+    }
+
+    const density = totalWords / totalWidth;
+    return Number.isFinite(density) && density > 0 ? density : 0;
 };
 
 /**
@@ -122,6 +229,7 @@ export const isPoetryPair = (
     options: PoetryDetectionOptions = DEFAULT_POETRY_OPTIONS,
 ): boolean => {
     const minWordCount = options.minWordCount ?? DEFAULT_MIN_WORD_COUNT;
+    const maxVerticalGapRatio = options.maxVerticalGapRatio ?? DEFAULT_MAX_VERTICAL_GAP_RATIO;
     const pairWidthSimilarityRatio = options.pairWidthSimilarityRatio ?? DEFAULT_PAIR_WIDTH_SIMILARITY;
     const pairWordCountSimilarityRatio = options.pairWordCountSimilarityRatio ?? DEFAULT_PAIR_WORD_SIMILARITY;
     const words1 = getWordCount(obs1.text);
@@ -132,48 +240,40 @@ export const isPoetryPair = (
         return false;
     }
 
-    // Check width similarity
-    const avgWidth = (obs1.bbox.width + obs2.bbox.width) / 2;
-    const widthDiffRatio = Math.abs(obs1.bbox.width - obs2.bbox.width) / avgWidth;
-    if (widthDiffRatio >= pairWidthSimilarityRatio) {
+    const { avgWidth, isCompatible: hasCompatibleWidths } = hasCompatiblePairWidths(
+        obs1,
+        obs2,
+        pairWidthSimilarityRatio,
+    );
+    if (!hasCompatibleWidths) {
         return false;
     }
 
-    // Check word count similarity
-    const maxWords = Math.max(words1, words2);
-    const wordCountDiffRatio = Math.abs(words1 - words2) / maxWords;
-    if (wordCountDiffRatio >= pairWordCountSimilarityRatio) {
+    if (!hasCompatibleWordCounts(words1, words2, pairWordCountSimilarityRatio)) {
+        return false;
+    }
+
+    if (!hasCompatibleVerticalGap(obs1, obs2, maxVerticalGapRatio)) {
         return false;
     }
 
     // For pairs (hemistichs), the centering can be less strict, especially if
     // there is a clear visual gap separating them, which is a common poetic layout.
-    const leftObs = obs1.bbox.x < obs2.bbox.x ? obs1 : obs2;
-    const rightObs = obs1.bbox.x < obs2.bbox.x ? obs2 : obs1;
-    const gap = rightObs.bbox.x - (leftObs.bbox.x + leftObs.bbox.width);
+    const { gap, leftObs, rightObs } = getOrderedPairObservations(obs1, obs2);
+
+    if (isNumericOnlyToken(leftObs.text)) {
+        return false;
+    }
 
     // A gap is considered significant if it's large relative to the page width OR the text width.
     // This allows for more flexible detection of visually separated hemistichs.
     const hasSignificantGap = gap > imageWidth * 0.07 || gap > avgWidth * 0.15;
-    const centeringOptions = hasSignificantGap
-        ? {
-              ...resolveCenteringOptions(options),
-              centerToleranceRatio: (options.centerToleranceRatio ?? DEFAULT_CENTER_TOLERANCE) * 2.5,
-              minMarginRatio: (options.minMarginRatio ?? DEFAULT_MIN_MARGIN) * 0.75,
-          }
-        : resolveCenteringOptions(options);
+    if (hasSignificantGap && hasAsymmetricSparseGap(leftObs, rightObs, gap, avgWidth, imageWidth)) {
+        return false;
+    }
 
-    // Check if the pair as a whole is centered using the determined options.
-    const leftX = Math.min(obs1.bbox.x, obs2.bbox.x);
-    const rightmostPoint = Math.max(obs1.bbox.x + obs1.bbox.width, obs2.bbox.x + obs2.bbox.width);
-    const combinedBbox = {
-        height:
-            Math.max(obs1.bbox.y + obs1.bbox.height, obs2.bbox.y + obs2.bbox.height) -
-            Math.min(obs1.bbox.y, obs2.bbox.y),
-        width: rightmostPoint - leftX,
-        x: leftX,
-        y: Math.min(obs1.bbox.y, obs2.bbox.y),
-    };
+    const centeringOptions = resolvePairCenteringOptions(hasSignificantGap, options);
+    const combinedBbox = toCombinedBbox(obs1, obs2);
 
     return isObservationCentered(combinedBbox, imageWidth, centeringOptions);
 };


### PR DESCRIPTION
## GPT 5.3 Codex Poetry Detection MVP Core Implementation Plan (No Snapshot Regeneration)

### Summary
Implement the selected **MVP core only** scope in `/Users/rhaq/workspace/kokokor`:
1. Enforce `maxVerticalGapRatio` in pair detection.
2. Replace fragile `split(' ')` counting with one shared conservative word counter.
3. Add invalid-baseline sanity handling (numeric safety only, no behavior-expanding fallback model).
4. Add low-risk ToC/column false-positive guards for pair detection.
5. Keep default punctuation behavior unchanged for single wide-line detection.
6. Add targeted `bun:test` coverage and run full regression checks without rewriting snapshots.

### Public API / Types Changes
- **No breaking public API changes.**
- Existing `PoetryDetectionOptions.maxVerticalGapRatio` remains unchanged and is now actually enforced.
- No new required options.
- Keep `PROSE_PUNCTUATION_PATTERN` behavior unchanged in `isWidePoeticLine`.

### Files In Scope
- `src/utils/poetry.ts`
- `src/utils/poetry.test.ts`
- `src/index.test.ts` (only if needed; no snapshot regeneration)
- Optional comments/docs-only touch:
  - `src/types.ts`
  - `src/utils/constants.ts`

### Detailed Implementation Spec

#### 1) Vertical gate enforcement in `isPoetryPair`
- In `isPoetryPair`, after min-word and similarity checks, add a strict vertical compatibility gate:
  - `centerY1 = obs1.bbox.y + obs1.bbox.height / 2`
  - `centerY2 = obs2.bbox.y + obs2.bbox.height / 2`
  - `dy = abs(centerY1 - centerY2)`
  - `avgHeight = (obs1.bbox.height + obs2.bbox.height) / 2`
  - Reject if `dy > maxVerticalGapRatio * avgHeight`.
- Option resolution:
  - `maxVerticalGapRatio = options.maxVerticalGapRatio ?? DEFAULT_POETRY_OPTIONS.maxVerticalGapRatio`
- Keep default at current `2.0` for migration stability.

#### 2) Shared conservative word counter
- Replace all direct `split(' ')` word counting in poetry logic with a shared helper in `poetry.ts`.
- Helper behavior (deterministic, low-regression):
  - Normalize NBSP to regular space.
  - Strip tatweel (`\u0640`).
  - Trim whitespace.
  - Count non-empty whitespace-separated runs (`\S+` equivalent).
- Use this helper in:
  - `calculateAverageProseDensity`
  - `isPoetryPair`
  - `isWidePoeticLine`
  - Any internal density/similarity computations.
- Avoid regex object creation inside hot loops.

#### 3) Baseline sanity guard (numeric safety only)
- Keep current precision behavior for zero-baseline pages (do **not** introduce a global prose-density fallback constant in this pass).
- Add guard:
  - If computed prose density is non-finite (`NaN`, `Infinity`) or `<= 0`, treat as unavailable baseline and keep existing `isWidePoeticLine` rejection path.
- Goal: numeric safety without broad classification drift.

#### 4) ToC / numeric-left false-positive guard
- In `isPoetryPair`, detect left visual chunk (smaller `x`).
- Add hard reject for obvious ToC/page-number-style left chunk:
  - Left text matches numeric-only token pattern with optional wrappers/punctuation (Arabic or Latin digits), e.g. `"(١٢)"`, `"12"`, `" ٣ "`.
  - Pattern should allow wrappers but require substantive content to be digits.
- This guard runs before centering relaxation return path.

#### 5) Column-like false-positive guard (conservative)
- Apply only when the relaxed-centering path is active (`hasSignificantGap` true).
- Add inner-edge symmetry constraint around page center:
  - `innerLeft = leftObs.x + leftObs.width`
  - `innerRight = rightObs.x`
  - `pageCenter = imageWidth / 2`
  - `leftDelta = abs(pageCenter - innerLeft)`
  - `rightDelta = abs(innerRight - pageCenter)`
  - Reject when `abs(leftDelta - rightDelta) > imageWidth * 0.12`
- Purpose: reduce asymmetric cross-column matches while preserving balanced hemistich pairs.

#### 6) Keep punctuation default unchanged
- Do not change this line’s behavior in this pass:
  - hard reject in `isWidePoeticLine` when `PROSE_PUNCTUATION_PATTERN` matches.
- Soft punctuation mode is explicitly deferred.

### Test Plan (`bun:test`, `it('should...')`)

#### A) New/updated unit tests in `src/utils/poetry.test.ts`
1. `it('should reject poetry pair when vertical center gap exceeds maxVerticalGapRatio')`
2. `it('should accept poetry pair near vertical gap boundary')`
3. `it('should count words robustly with multiple spaces, NBSP, and tatweel')`
4. `it('should use shared word count consistently in prose density and pair checks')`
5. `it('should reject pair when left chunk is numeric-only (ToC-like)')`
6. `it('should reject asymmetric cross-column-like pair under relaxed centering')`
7. `it('should keep punctuation-reject behavior unchanged for wide single-line poetry')` (regression assertion)

#### B) Optional integration test in `src/index.test.ts`
- Only add assertions if needed for new false-positive fixtures.
- **No snapshot regeneration** (`WRITE_SNAPSHOTS` must remain false/unset).

### Regression / Acceptance Criteria
- `bun test` passes fully.
- `bun run build` passes.
- Optional targeted lint check on touched files:
  - `bunx biome check src/utils/poetry.ts src/utils/poetry.test.ts`
- Snapshot policy:
  - Do **not** run `WRITE_SNAPSHOTS=true`.
  - Any snapshot diff is treated as regression and must be reviewed, not rewritten.

### Execution Sequence (implementation order)
1. Add failing tests for vertical gate + numeric-left + column-symmetry + word-count helper behavior.
2. Implement minimal `poetry.ts` changes to satisfy tests.
3. Run focused tests:
   - `bun test src/utils/poetry.test.ts`
4. Run full regression:
   - `bun test`
5. Run build:
   - `bun run build`
6. If any integration assertion needs update in `index.test.ts`, edit expectations only (no snapshot rewrite).

### Assumptions / Defaults Locked
- Scope is **MVP core only** (as selected).
- No smoothing pass in this implementation.
- No >2 fragment pairing aggregation in this implementation.
- No default punctuation softening in this implementation.
- `maxVerticalGapRatio` default remains `2.0`.
- Snapshot files under `test/mixed/*.txt` remain canonical and unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable poetry pair delimiter option for customized text merging in poetry handling
  * Enhanced poetry detection logic with improved robustness and accuracy

* **Documentation**
  * Updated API documentation with revised parameter naming and method signatures
  * Added examples for new poetry delimiter configuration option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->